### PR TITLE
Revert "OCP-1219: Disable CLI -remoting option"

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,4 +27,4 @@ suites:
         - ["private_network", { ip: "172.29.129.191" }]
 
 transport:
-   max_ssh_sessions: 4
+  max_ssh_sessions: 4

--- a/files/jenkins.CLI.xml
+++ b/files/jenkins.CLI.xml
@@ -1,4 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<jenkins.CLI>
-    <enabled>false</enabled>
-</jenkins.CLI>

--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -28,12 +28,3 @@
   args:
     chdir:   "{{ jenkins_helper_scripts_dir }}"
     creates: "{{ jenkins_helper_scripts_dir }}/jenkins-cli.jar"
-
-- name: Disable CLI 'remoting' option for security
-  copy:
-    src: jenkins.CLI.xml
-    dest: "{{ jenkins_home }}"
-    owner: "{{ jenkins_user }}"
-    group: "{{ jenkins_group }}"
-    mode: 0644
-  notify: Restart jenkins

--- a/test/integration/master/serverspec/default_spec.rb
+++ b/test/integration/master/serverspec/default_spec.rb
@@ -19,8 +19,6 @@ if os[:family] =~ /centos|redhat/
   jenkins_prereq_pkgs = %w( curl unzip git python-devel python-pip )
 end
 
-jenkins_cli_xml = "#{jenkins_home_dir}/jenkins.CLI.xml"
-
 jenkins_prereq_pkgs.each do |pkg|
   describe package(pkg) do
     it { should be_installed }
@@ -59,10 +57,6 @@ end
 
 describe port(jenkins_http_port) do
   it { should be_listening }
-end
-
-describe file(jenkins_cli_xml) do
-	its(:content) { should match(%r{<enabled>false</enabled>}) }
 end
 
 


### PR DESCRIPTION
This commit broke running ansible on jenkins-master, as we use
jenkins-cli.jar to create slave users, and we do not use ssh or http
currently to authenticate this.