### PR TITLE
[DM] Fix kitchen tests for master according to changes in tasks/cli.yml

### DIFF
--- a/test/integration/master/serverspec/default_spec.rb
+++ b/test/integration/master/serverspec/default_spec.rb
@@ -70,16 +70,10 @@ describe file(jenkins_scripts_dir) do
   it { should be_mode 755 }
 end
 
-%w(
-  jenkins-cli.jar
-  cli_helper.groovy
-  grant_global_matrix_permissions.groovy
-).each do |f|
-  describe file("#{jenkins_scripts_dir}/#{f}") do
-    it { should be_file }
-    it { should be_owned_by jenkins_user }
-    it { should be_mode 644 }
-  end
+describe file("#{jenkins_scripts_dir}/jenkins-cli.jar") do
+  it { should be_file }
+  it { should be_owned_by jenkins_user }
+  it { should be_mode 644 }
 end
 
 ###################


### PR DESCRIPTION
kitchen verify was failing for jenkins master
```
File "/mnt/jenkins/scripts/cli_helper.groovy"
         should be file (FAILED - 1)
         should be owned by "jenkins" (FAILED - 2)
         should be mode 644 (FAILED - 3)
       
       File "/mnt/jenkins/scripts/grant_global_matrix_permissions.groovy"
         should be file (FAILED - 4)
         should be owned by "jenkins" (FAILED - 5)
         should be mode 644 (FAILED - 6)
```

According to the recent code changes in the tasks/cli.yml, these two files are not copied over to the instance anymore. 
This change edits the kitchen test for jenkins master to compliment the above mentioned code change.